### PR TITLE
Simplify tarball extraction for Docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,14 @@ workflows:
       - dist
       - build-docker-image:
           context: Shared Secrets
+          filters:
+            branches:
+              ignore: mode-release-8.x
       - publish-docker-image:
           context: Shared Secrets
           filters:
             branches:
-              only:
-                - mode-release-8.x
+              only: mode-release-8.x
 
 
 

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -32,11 +32,10 @@ ENV PATH=$PATH:$VOLTDB_DIST/bin
 
 COPY --from=builder /opt/voltdb/obj/release/voltdb-community.tar.gz voltdb-community.tar.gz
 
-RUN tar -zxf voltdb-community.tar.gz
-RUN mv voltdb-community-* voltdb-community
 RUN mkdir -p ${VOLTDB_DIST}
-RUN cp -r voltdb-community/* $VOLTDB_DIST
-RUN rm -r voltdb-community voltdb-community.tar.gz
+
+RUN tar -zxf voltdb-community.tar.gz --strip-components=1 -C $VOLTDB_DIST && \
+  rm -r voltdb-community.tar.gz
 
 RUN useradd -ms /bin/bash voltdb
 USER voltdb


### PR DESCRIPTION
- Simplify tarball extraction (follow up for: https://github.com/mode/voltdb/pull/8)
- Add missing filter to redundant ci job