### PR TITLE
Plug memory leak in COMPACT_COUNT_DISTINCT's push down

### DIFF
--- a/src/ee/executors/aggregateexecutor.cpp
+++ b/src/ee/executors/aggregateexecutor.cpp
@@ -538,10 +538,10 @@ public:
     {
         assert (type == VALUE_TYPE_VARBINARY);
         uint32_t byteSize =  roaring().getSizeInBytes();
-        char *serializedBytes = new char[byteSize];
+        std::unique_ptr<char[]> serializedBytes(new char[byteSize]);
 
-        roaring().write(serializedBytes);
-        return ValueFactory::getTempBinaryValue(serializedBytes, byteSize);
+        roaring().write(serializedBytes.get());
+        return ValueFactory::getTempBinaryValue(serializedBytes.get(), byteSize);
     }
 };
 


### PR DESCRIPTION
I spotted what appears to be a memory leak in ValuesToCompactAgg (COMPACT_COUNT_DISTINCT's "push down" function). The code allocates a new `char*` of size `byteSize` but never deallocates it. The pointer is passed to `ValueFactory::getTempBinary(…)`, which copies the given data rather than taking ownership of the pointer.

The fix simply moves the `char*` into a `std::unique_ptr<char[]>`, which will automatically clean up when it goes out of scope at the end of the function.

Tested locally via [TestApproxCountDistinctSuite](https://github.com/mode/voltdb/blob/b1eb4ba9e7eeccc56d7fc9e21ecc0bcf02f88148/tests/frontend/org/voltdb/regressionsuites/TestApproxCountDistinctSuite.java) to verify that there are no new crashes and that the tests still pass.