### PR TITLE
Cap PERCENTILE_N/MEDIAN methods at 1M rows per partition

### DIFF
--- a/src/ee/executors/aggregateexecutor.cpp
+++ b/src/ee/executors/aggregateexecutor.cpp
@@ -601,6 +601,11 @@ public:
 
         // We don't track null or nonsensical values.
         if (!val.isNull() && !val.isNaN()) {
+            if (m_values.size() == 1000000) {
+                throw SQLException(SQLException::volt_user_defined_function_error,
+                        "Too many data points for percentile");
+            }
+
             m_values.push_back(doubleValue(val));
         }
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestPercentileSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestPercentileSuite.java
@@ -199,7 +199,7 @@ public class TestPercentileSuite extends RegressionSuite {
         // Get keys suitable for targeting rows to specific partitions.
         final List<Integer> partitionKeys = getIntegerPartitionKeys();
 
-        // Insert 1,000,000 rows into each of three partitions
+        // Insert 1,000,000 rows into each of the partitions
         for (int partitionKey : partitionKeys) {
             // Give each partition a window of 10M values to work within
             final int idOffset = partitionKey * 10_000_000;


### PR DESCRIPTION
Implements a 1M row cap on PERCENTILE_N/MEDIAN methods as a safeguard
against runaway memory usage.

Without this check it's possible that the dist nodes on each
partition could put an effectively infinite number of doubles into
the underlying STL vector, opening the door for memory exhaustion.

The large table test has been updated to fill each of the available
partitions up with 1M rows, test that the functions work properly, and
then add 1 more row and make sure that the function aborts
as expected.