### PR TITLE
Disable memory checking on dist'd builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run: apt-get install -y openjdk-8-jdk-headless ant build-essential cmake python git
       - checkout
       - run: ant clean
-      - run: ant dist
+      - run: ant -Djmemcheck=NO_MEMCHECK dist
       - run: cp obj/release/voltdb-community-*.tar.gz obj/release/mode-voltdb-community.tar.gz
       - store_artifacts:
           path: obj/release/mode-voltdb-community.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ commands:
             apt-key fingerprint 0EBFCD88
             add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
             apt-get update
-            apt-get install docker-ce-cli
+            apt-get install -y docker-ce-cli
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
 jobs:
 
   dist:
-    resource_class: 2xlarge
+    resource_class: xlarge
     docker:
       - image: ubuntu:16.04
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
 jobs:
 
   dist:
-    resource_class: xlarge
+    resource_class: 2xlarge
     docker:
       - image: ubuntu:16.04
     steps:

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /opt/voltdb
 COPY . .
 
 RUN ant clean
-RUN ant dist | ts '[%Y-%m-%d %H:%M:%S]'
+RUN ant -Djmemcheck=NO_MEMCHECK dist | ts '[%Y-%m-%d %H:%M:%S]'
 RUN cp obj/release/voltdb-community-*.tar.gz obj/release/voltdb-community.tar.gz
 
 


### PR DESCRIPTION
Gets rid of the following message (as well as any performance penalties we may be paying):

> WARN: Strict java memory checking is enabled, don't do release builds or performance runs with this enabled. Invoke "ant clean" and "ant -Djmemcheck=NO_MEMCHECK" to disable.

I've confirmed this by running the prior release locally:

```
% docker run -it --rm ghcr.io/mode/voltdb/voltdb:8.4.11-8be892170dd5a44ac99bc17199459007a02f0fa0
Initializing VoltDB...

 _    __      ____  ____  ____
| |  / /___  / / /_/ __ \/ __ )
| | / / __ \/ / __/ / / / __  |
| |/ / /_/ / / /_/ /_/ / /_/ /
|___/\____/_/\__/_____/_____/

--------------------------------

Build: 8.4.11 This is not from a known repository Community Edition
Loaded node-specific settings from voltdbroot/config/path.properties
Connecting to VoltDB cluster as the leader...
Host id of this node is: 0
Starting a new database cluster
WARN: User authentication is not enabled. The database is accessible and could be modified or shut down by anyone on the network.
Initializing the database. This may take a moment...
WARN: Strict java memory checking is enabled, don't do release builds or performance runs with this enabled. Invoke "ant clean" and "ant -Djmemcheck=NO_MEMCHECK" to disable.
WARN: This is not a highly available cluster. K-Safety is set to 0.
WARN: Durability is turned off. Command logging is off.
Server Operational State is: NORMAL
Server completed initialization.
```

We can see the warning regarding memory checking above. Then running the newly built release:

```
% docker run -it --rm ghcr.io/mode/voltdb/voltdb:8.4.11-29708815499c03ac6b67e6de0ac7eb01afbd2c51
Initializing VoltDB...

 _    __      ____  ____  ____
| |  / /___  / / /_/ __ \/ __ )
| | / / __ \/ / __/ / / / __  |
| |/ / /_/ / / /_/ /_/ / /_/ /
|___/\____/_/\__/_____/_____/

--------------------------------

Build: 8.4.11 This is not from a known repository Community Edition
Loaded node-specific settings from voltdbroot/config/path.properties
Connecting to VoltDB cluster as the leader...
Host id of this node is: 0
Starting a new database cluster
WARN: User authentication is not enabled. The database is accessible and could be modified or shut down by anyone on the network.
Initializing the database. This may take a moment...
WARN: This is not a highly available cluster. K-Safety is set to 0.
WARN: Durability is turned off. Command logging is off.
Server Operational State is: NORMAL
Server completed initialization.
```

We see that there is no longer a memory checking warning.